### PR TITLE
fix if a mixin/func was nested in @media

### DIFF
--- a/specs/index.js
+++ b/specs/index.js
@@ -52,4 +52,45 @@ describe('scss split creation', function () {
       expect(x.splits[0]).to.equal('div h2 { color: brand-color(c4); }');
     });
   });
+
+  it('handles brand mixins inside media queries', function () {
+    const sassString = `
+div {
+  span {
+    span {
+      @media (min-width: 40em) {
+        @include brand(foo) {
+          color: red;
+        }
+      }
+    }
+  }
+}`;
+    const parsed = parse(sassString);
+
+    parsed.then(x => {
+      expect(x.splits[0]).to.equal('@media (min-width: 40em) {');
+      expect(x.splits[1]).to.equal('@include brand(foo) {\n        div span span {\n            color: red\n        }\n    }');
+    });
+  });
+
+  it('handles brand functions inside media queries', function () {
+    const sassString = `
+div {
+  span {
+    span {
+      @media (min-width: 40em) {
+        foo: bar;
+        color: brand-color(c4);
+      }
+    }
+  }
+}`;
+    const parsed = parse(sassString);
+
+    parsed.then(x => {
+      expect(x.splits[0]).to.equal('@media (min-width: 40em) {');
+      expect(x.splits[1]).to.equal('div span span { color: brand-color(c4); }');
+    });
+  });
 });


### PR DESCRIPTION
@robtarr :eyes: on this please? Basically I moved the `walkAtRules` "up" a level because the un-nesting plugin unwraps media rules so that the SCSS looks like:
```scss
@media (min-width: 40em) {
  @include brand(foo) {
    div span span p {
      color: red;
    }
  }
}
```
`walkRules` wasn't cutting it, since `@` is an *at*rule, not a normal rule. 

I also added this check into the regular brand function parsing.