### PR TITLE
account for doubly nested "brand" mixins

### DIFF
--- a/parseSCSS.js
+++ b/parseSCSS.js
@@ -13,9 +13,11 @@ const parser = (css) => {
   const parseAtRule = (at) => {
     if (/brand/.test(at.params)) {
       if (at.parent.type === 'atrule') {
-        splits.push(`@${at.parent.name} ${at.parent.params} {`);
-        splits.push(at.toString());
-        splits.push('}');
+        if (!/brand/.test(at.parent.params)) {
+          splits.push(`@${at.parent.name} ${at.parent.params} {`);
+          splits.push(at.toString());
+          splits.push('}');
+        }
       } else {
         splits.push(`${at.parent.selector} {`);
         splits.push(at.toString());

--- a/specs/index.js
+++ b/specs/index.js
@@ -93,4 +93,21 @@ div {
       expect(x.splits[1]).to.equal('div span span { color: brand-color(c4); }');
     });
   });
+
+  it('does not unwrap doubly nested brand mixins', function () {
+    const sassString = `
+body {
+  margin: 0;
+
+  @include brand(foo) {
+    @include brand-text();
+  }
+}
+`;
+    const parsed = parse(sassString);
+
+    parsed.then(x => {
+      expect(x.splits[1]).to.equal('@include brand(mozo) {\n    @include brand-text();\n  }');
+    });
+  });
 });


### PR DESCRIPTION
Sometimes "brand" mixins will be nested, e.g. 
```scss
$current-brand: foo;

@mixin brand($mixin-brand) {
  @if $current-brand == $mixin-brand {
    @content;
  }
}

@mixin brand-text () {
  @include brand(foo) {
    font-family: Arial;
  }
}

body {
  margin: 0;

  @include brand(foo) {
    @include brand-text();
  }
}
``` 
The goal here is to have the `body` when in brand `foo` have the `brand-text` output, e.g.

```scss
body {
  margin: 0;
}
```

and

```scss
body {
  font-family: Arial
}
```