### PR TITLE
:sparkle: feat: Strip SCSS comments before processing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scss-splinter",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Parse and split SCSS files based on functions and mixins.",
   "main": "index.js",
   "scripts": {

--- a/parseSCSS.js
+++ b/parseSCSS.js
@@ -69,11 +69,13 @@ const parser = (css) => {
     params = config;
     params.keyword = config.keyword || 'brand';
 
+    const css = params.css.replace(/(\/\/.*)/g, '');
+
     //https://github.com/postcss/postcss-nested#options
     //use the bubble option to specify mixins to unwrap
     const processor = postcss([nest({bubble: [params.keyword]}), brandParse()]);
 
-    return processor.process(params.css, { syntax })
+    return processor.process(css, { syntax })
     .then(x => ({ css: x.css, splits: splits }));
   };
 

--- a/specs/index.js
+++ b/specs/index.js
@@ -169,4 +169,19 @@ body {
         .to.equal('@include split(foo) {\n      margin: 0;\n    }');
     });
   });
+
+  it('strips comments', function () {
+    const sassString = `
+h1 {
+  // comment
+  foo: bar;
+}
+  `;
+    const parsed = parse({ css: sassString });
+
+    return parsed.then(x => {
+      expect(x.css)
+        .to.equal('\nh1 {\n  \n  foo: bar;\n}\n  ');
+    });
+  });
 });


### PR DESCRIPTION
`SCSS` comments were breaking postCSS, causing any rules after a comment to be inlined, and thus turning those rules into comments. This removes all `//` comments before processing, which removes this error case.